### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,8 @@ async function resolve(name, base) {
 
 export var require = requireFrom(resolve);
 
-export function requireFrom(resolver) {
-  const cache = new Map;
+export function requireFrom(resolver, cache) {
+  cache = cache || new Map;
   const requireBase = requireRelative(null);
 
   function requireAbsolute(url) {
@@ -102,7 +102,7 @@ export function requireFrom(resolver) {
         if (typeof name !== "string") return name;
       }
       return resolver(name, base);
-    });
+    }, cache);
   }
 
   function require(name) {


### PR DESCRIPTION
Set cache as a parameter of the requireFrom method to share loaded libraries between all require methods.

In the previous implementation the "alias" method creates a new "require" function with its own private cache object. This approach leads to creation of multiple copies of the same loaded libraries.